### PR TITLE
Add link to Gaston's hosted documentation

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -62,3 +62,8 @@ method = "hosted"
 name = "DifferentialEquations"
 location = "https://github.com/JuliaDiffEq/DiffEqDocs.jl.git"
 method = "git-repo"
+
+[4b11ee91-296f-5714-9832-002c20994614]
+name = "Gaston"
+location = "https://mbaz.github.io/Gaston.jl/stable/"
+method = "hosted"


### PR DESCRIPTION
JuliaHub cannot build Gaston's documentation because the link environment lacks `gnuplot` (see https://discourse.julialang.org/t/ann-juliahub-explore-run-scale/41135/14?u=mbaz).