### PR TITLE
Set Omniscape.jl as hosted 

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -72,3 +72,8 @@ method = "hosted"
 name = "CMBLensing"
 location = "https://cosmicmar.com/CMBLensing.jl/stable/"
 method = "hosted"
+
+[a38d70fc-99f5-11e9-1e3d-cbca093024c3]
+name = "Omniscape"
+location = "https://docs.circuitscape.org/Omniscape.jl/stable/"
+method = "hosted"


### PR DESCRIPTION
Package versions (Omniscape v0.5.8)  takes too long (~3hrs) to generate documenter docs