### PR TITLE
Opt out for Manopt.jl

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -238,6 +238,11 @@ name = "Optimization"
 location = "https://docs.sciml.ai"
 method = "hosted"
 
+[0fc0a36d-df90-57f3-8f93-d78a9fc72bb5]
+name = "Manopt"
+location = "https://manoptjl.org"
+method = "hosted"
+
 [5a33fad7-5ce4-5983-9f5d-5f26ceab5c96]
 name = "GeometricIntegratorsDiffEq"
 location = "https://docs.sciml.ai"


### PR DESCRIPTION
Use https://manoptjl.org/ as the hosted location.

cc: @kellertuer