### PR TITLE
Opt out for IPUToolkit.jl

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -238,6 +238,11 @@ name = "SciMLBase"
 location = "https://docs.sciml.ai"
 method = "hosted"
 
+[92e0b95a-4011-435a-96f4-10064551ddbe]
+name = "IPUToolkit"
+location = "https://juliaipu.github.io/IPUToolkit.jl/"
+method = "hosted"
+
 [1222c4b2-2114-5bfd-aeef-88e4692bbb3e]
 name = "julia"
 location = "https://docs.julialang.org"


### PR DESCRIPTION
As I mentioned on Slack, I don't expect you can reasonably be able to build documentation of my package [`IPUToolkit.jl`](https://github.com/JuliaIPU/IPUToolkit.jl), and in fact at the moment [docs hosted on JuliaHub](https://docs.juliahub.com/General/IPUToolkit/stable/) are completely non-existent