### PR TITLE
Update EntropyHub website URL

### DIFF
--- a/Registry.toml
+++ b/Registry.toml
@@ -355,7 +355,7 @@ method = "hosted"
 
 [3938faea-3bfa-4bc3-8092-0c6746ff9af1]
 name = "EntropyHub"
-location = "https://mattwillflood.github.io/EntropyHub.jl/"
+location = "https://mattwillflood.github.io/EntropyHub.jl/stable/"
 method = "hosted"
 
 [7f7a1694-90dd-40f0-9382-eb1efda571ba]


### PR DESCRIPTION
I needed to add '/stable' to the end of the URL to point to the most recent docs.