### PR TITLE
Add a comment to specification in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are three options for specifying how (with the `method` key) and where (wi
 
 Each package is specified by UUID, which is also the top-level key. Required sub-keys are `method`, `location`, and `name`:
 ```
+# replace by the actual UUID of the package "PackageName" 
 [uuid]
 name = "PackageName"
 method = "hosted"


### PR DESCRIPTION
As [uuid] could have been a valid TOML section header, it was not obvious that it has to be replaced by the actual TOML.